### PR TITLE
Adapted java version check to work with newer versions

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -87,7 +87,8 @@ checkJava() {
     fi
     if [[ "$_java" ]]; then
         version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-        if [[ "$version" < "1.7" ]]; then
+        major_version=$(echo $version | awk -F '.' '{print $1}')
+        if [[ "$major_version" -lt "7" && "$version" < "1.7" ]]; then
             echo "This script requires Java 1.7 or later to run properly."
             abort
         fi


### PR DESCRIPTION
Recent java versions have a 2 digit version number (e.g. `11.0.4`) so the string comparison against `1.7` fails.
-> Added first an integer check against the major version.